### PR TITLE
Migrate to use v0.14 API

### DIFF
--- a/fluent-plugin-syslog-tls.gemspec
+++ b/fluent-plugin-syslog-tls.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.0'
 
   s.add_runtime_dependency 'fluentd', '~> 0.14.0'
-  s.add_runtime_dependency 'fluent-mixin-config-placeholders', '~> 0.3'
 
   s.add_development_dependency 'minitest', '~> 5.8'
   s.add_development_dependency 'minitest-stub_any_instance', '~> 1.0.0'

--- a/lib/fluent/plugin/out_syslog_tls.rb
+++ b/lib/fluent/plugin/out_syslog_tls.rb
@@ -16,11 +16,10 @@
 require 'fluent/mixin/config_placeholders'
 require 'socket'
 
-module Fluent
-  class SyslogTlsOutput < Fluent::Output
+module Fluent::Plugin
+  class SyslogTlsOutput < Output
     Fluent::Plugin.register_output('syslog_tls', self)
 
-    include Fluent::Mixin::ConfigPlaceholders
     include Fluent::HandleTagNameMixin
 
     helpers :inject, :formatter, :compat_parameters
@@ -60,8 +59,8 @@ module Fluent
     end
 
     def shutdown
-      super
       @loggers.values.each(&:close)
+      super
     end
 
     # This method is called before starting.
@@ -114,8 +113,7 @@ module Fluent
       @formatter.format(tag, time, record)
     end
 
-    def emit(tag, es, chain)
-      chain.next
+    def process(tag, es)
       es.each do |time, record|
         record.each_pair do |_, v|
           v.force_encoding('utf-8') if v.is_a?(String)

--- a/lib/fluent/plugin/out_syslog_tls.rb
+++ b/lib/fluent/plugin/out_syslog_tls.rb
@@ -15,6 +15,7 @@
 
 require 'socket'
 require 'syslog_tls/logger'
+require 'fluent/plugin/output'
 
 module Fluent::Plugin
   class SyslogTlsOutput < Output

--- a/lib/fluent/plugin/out_syslog_tls.rb
+++ b/lib/fluent/plugin/out_syslog_tls.rb
@@ -13,14 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'fluent/mixin/config_placeholders'
 require 'socket'
 
 module Fluent::Plugin
   class SyslogTlsOutput < Output
     Fluent::Plugin.register_output('syslog_tls', self)
-
-    include Fluent::HandleTagNameMixin
 
     helpers :inject, :formatter, :compat_parameters
 

--- a/lib/fluent/plugin/out_syslog_tls.rb
+++ b/lib/fluent/plugin/out_syslog_tls.rb
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 require 'socket'
+require 'syslog_tls/logger'
 
 module Fluent::Plugin
   class SyslogTlsOutput < Output
@@ -51,7 +52,6 @@ module Fluent::Plugin
 
     def initialize
       super
-      require 'syslog_tls/logger'
       @loggers = {}
     end
 


### PR DESCRIPTION
Hi, thanks to trying to use Fluentd v0.14.
But I've found several wrong usage v0.14 API:

* Should inherits `Fluent::Plugin::Output` instead of `Fluent::Output'
* Stop to use `Mixin` for v0.12
  * Users shouldn't use tag for routing. In v0.14, it should use label for routing  
* Use `#process` for non-buffered v0.14 Output Plugin API instead of `#emit` for v0.12
* Use v0.14 test driver instead of ancient v0.12 test driver
 
---

I've tried to migrate to use v0.14 Input Plugin API.
This PR contains major update change.
Could you bump up major version if releasing new version of gem?
And please refer http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12 before release new version.

Thanks in advance.