### PR TITLE
support SNI

### DIFF
--- a/lib/syslog_tls/ssl_transport.rb
+++ b/lib/syslog_tls/ssl_transport.rb
@@ -113,6 +113,7 @@ module SyslogTls
       ctx.cert = OpenSSL::X509::Certificate.new(File.read(client_cert)) if client_cert
       ctx.key = OpenSSL::PKey::read(File.read(client_key)) if client_key
       socket = OpenSSL::SSL::SSLSocket.new(tcp, ctx)
+      socket.hostname = host
       socket.sync_close = true
       socket
     end


### PR DESCRIPTION
Support SNI by setting hostname with the host value for server that serve different certificate for each DNS.

https://stackoverflow.com/questions/30244745/opensslsslsslcontext-sni-servername-cb-not-working?answertab=active#tab-top